### PR TITLE
Changed release-it configuration

### DIFF
--- a/orders-module/.release-it.json
+++ b/orders-module/.release-it.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://unpkg.com/release-it/schema/release-it.json",
   "git": {
-    "changelog" : ""
+    "changelog" : "",
+    "requireBranch": "release/*"
   },
   "github": {
     "release": true


### PR DESCRIPTION
This pull request updates the release configuration for the `orders-module` to enforce branch restrictions during the release process.

Release configuration changes:

* [`orders-module/.release-it.json`](diffhunk://#diff-0b582305117f43223c292580af2ea52d7cd8dc27b6311eac383d06395d4600d2L4-R5): Added a `requireBranch` property with the value `"release/*"` to ensure releases can only be performed from branches matching the `release/*` pattern.