### PR TITLE
Potential fix for code scanning alert no. 8: Overly permissive regular expression range

### DIFF
--- a/sample-order-with-user-signin/src/components/FormFields/EmailField.tsx
+++ b/sample-order-with-user-signin/src/components/FormFields/EmailField.tsx
@@ -25,7 +25,7 @@ const EmailField: FC<Props> = ({ required = false, errors }) => {
                 {...register('email', {
                     required: required ? 'This field is required!' : false,
                     pattern: {
-                        value: /^[-!#-'*+/-9=?^-~]+(?:\.[-!#-'*+/-9=?^-~]+)*@[-!#-'*+/-9=?^-~]+(?:\.[-!#-'*+/-9=?^-~]{2,20})+$/i,
+                        value: /^[!#-'*+\/0-9=?^-~\-]+(?:\.[!#-'*+\/0-9=?^-~\-]+)*@[!#-'*+\/0-9=?^-~\-]+(?:\.[!#-'*+\/0-9=?^-~\-]{2,20})+$/i,
                         message: 'Invalid email address!',
                     },
                 })}


### PR DESCRIPTION
Potential fix for [https://github.com/infosoftas/s4-orders-js-sdk/security/code-scanning/8](https://github.com/infosoftas/s4-orders-js-sdk/security/code-scanning/8)

To fix the problem, we need to ensure that the dash (`-`) is interpreted as a literal character in the character class, not as a range operator. In regular expressions, a dash is interpreted as a range unless it is the first or last character in the character class, or escaped with a backslash (`\`). The best way to fix this is to move the dash to the end of the character class or escape it. This should be done for every character class in the regular expression where the dash is intended to be literal. Specifically, in the regex on line 28, update all instances of `[-!#-'*+/-9=?^-~]` to `[!#-'*+\/0-9=?^-~\-]` or, more simply, move the dash to the end: `[!#-'*+\/0-9=?^-~\-]`. Also, check for any other unescaped dashes in the regex and fix them similarly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
