### PR TITLE
19652: Required input fields should be trimmed before validating them

### DIFF
--- a/orders-module/src/components/FormFields/AddressField.tsx
+++ b/orders-module/src/components/FormFields/AddressField.tsx
@@ -41,7 +41,6 @@ const AddressField: FC<Props> = ({
                     required: required ? errorReqMsg : false,
                 })}
                 {...(required ? {
-                    value,
                     onBlur: () => {
                         const newValue = value?.trim() || '';
                         setValue(name, newValue);


### PR DESCRIPTION
My previous solution based on standard HTML attribute "pattern". It works! But only for "input" tags. "Address Field" is "textarea" (not "input"). So, "pattern" attribute is ignored for "textarea". Specially, for "textarea" was implemented work-around. "Address Field" is only one control based on "textarea". This fix should be enouph.