### PR TITLE
Update version of NPM "webpack-dev-server"

### DIFF
--- a/simple-orders-app/package-lock.json
+++ b/simple-orders-app/package-lock.json
@@ -58,7 +58,6 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -662,7 +661,6 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
             "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
             },
@@ -1488,7 +1486,6 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
             "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.27.1",
                 "@babel/helper-module-imports": "^7.27.1",
@@ -2668,6 +2665,114 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -3202,7 +3307,8 @@
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -3419,12 +3525,6 @@
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
             "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
         },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.14",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-            "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-            "optional": true
-        },
         "node_modules/@types/q": {
             "version": "1.5.8",
             "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
@@ -3449,9 +3549,9 @@
             }
         },
         "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
         },
         "node_modules/@types/semver": {
             "version": "7.7.1",
@@ -3536,7 +3636,6 @@
             "version": "5.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
             "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.4.0",
                 "@typescript-eslint/scope-manager": "5.62.0",
@@ -3588,7 +3687,6 @@
             "version": "5.62.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -3928,7 +4026,6 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4018,7 +4115,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4860,7 +4956,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.25",
                 "caniuse-lite": "^1.0.30001754",
@@ -4894,6 +4989,20 @@
             "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5811,12 +5920,6 @@
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
             "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         },
-        "node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "optional": true
-        },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5922,15 +6025,30 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/default-gateway": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+        "node_modules/default-browser": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
+            "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
             "dependencies": {
-                "execa": "^5.0.0"
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/define-data-property": {
@@ -6102,7 +6220,8 @@
         "node_modules/dom-accessibility-api": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "peer": true
         },
         "node_modules/dom-converter": {
             "version": "0.2.0",
@@ -6544,7 +6663,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -7855,6 +7973,21 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -8321,6 +8454,14 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+            "engines": {
+                "node": ">=10.18"
+            }
+        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8690,6 +8831,37 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -8715,6 +8887,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+            "integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-number": {
@@ -9079,7 +9262,6 @@
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
             "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^27.5.1",
                 "import-local": "^3.0.2",
@@ -9925,7 +10107,6 @@
             "version": "1.21.7",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -10281,6 +10462,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -10900,15 +11082,19 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dependencies": {
-                "@types/retry": "0.12.0",
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -11147,7 +11333,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
@@ -12214,7 +12399,6 @@
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -12542,7 +12726,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -12669,7 +12852,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -12692,7 +12874,6 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
             "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12746,7 +12927,7 @@
                 "tailwindcss": "^3.0.2",
                 "terser-webpack-plugin": "^5.2.5",
                 "webpack": "^5.64.4",
-                "webpack-dev-server": "^4.6.0",
+                "webpack-dev-server": "^5.2.1",
                 "webpack-manifest-plugin": "^4.0.2",
                 "workbox-webpack-plugin": "^6.4.1"
             },
@@ -13085,7 +13266,6 @@
             "version": "2.79.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
             "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -13130,6 +13310,17 @@
             "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
             "dependencies": {
                 "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -13315,7 +13506,6 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -14462,6 +14652,22 @@
                 }
             }
         },
+        "node_modules/tailwindcss/node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
         "node_modules/tapable": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -14617,6 +14823,21 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/thingies": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+            "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
         "node_modules/throat": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
@@ -14662,7 +14883,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -14725,6 +14945,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
             }
         },
         "node_modules/tryer": {
@@ -14814,7 +15049,6 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15206,7 +15440,6 @@
             "version": "5.103.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
             "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -15251,76 +15484,119 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/memfs": {
+            "version": "4.51.1",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.51.1.tgz",
+            "integrity": "sha512-Eyt3XrufitN2ZL9c/uIRMyDwXanLI88h/L3MoWqNY747ha3dMR9dWqp8cRT5ntjZ0U1TNuq4U91ZXK0sMBjYOQ==",
+            "dependencies": {
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
-            "peer": true,
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+            "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.21",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^2.0.0",
-                "default-gateway": "^6.0.3",
-                "express": "^4.17.3",
+                "express": "^4.21.2",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.6.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^2.4.1",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.4",
-                "ws": "^8.13.0"
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -15329,6 +15605,45 @@
                 "webpack-cli": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.7",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
+            "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/webpack-dev-server/node_modules/ws": {
@@ -15664,7 +15979,6 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15928,6 +16242,34 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/xml-name-validator": {


### PR DESCRIPTION
According following description:
https://github.com/infosoftas/s4-orders-js-sdk/security/dependabot/36

Version of dependency "webpack-dev-server" was updated from "5.2.0" to "5.2.1".

Additionally, it is not a real issue, because "webpack-dev-server" is NOT part of Order-SDK, this package is necessary for local deploying as part of development proccess.