### PR TITLE
18380: Return initial payment method

### DIFF
--- a/orders-module/src/components/OrderForm/OrderForm.tsx
+++ b/orders-module/src/components/OrderForm/OrderForm.tsx
@@ -1,4 +1,4 @@
-import { FC, ChangeEvent, Suspense, useState, useMemo, useEffect, useRef } from 'react';
+import { FC, ChangeEvent, Suspense, useState, useMemo, useEffect } from 'react';
 import { FormProvider, useForm, SubmitHandler } from 'react-hook-form';
 
 import { PaymentMethodEnum, UserActionEnum } from '../../enums/general';
@@ -148,10 +148,8 @@ const OrderForm: FC<Props> = ({
         formState: { errors },
     } = methods;
 
-    const userActionCallbackRef = useRef(userActionCallback);
-
     useEffect(() => {
-        userActionCallbackRef.current?.(UserActionEnum.SELECT_PAYMENT_METHOD, {
+        userActionCallback?.(UserActionEnum.SELECT_PAYMENT_METHOD, {
             paymentMethod: methods.getValues('paymentMethod'),
         });
     }, []);


### PR DESCRIPTION
Added a useEffect that sends the payment type that is selected by default when the component renders for the first time. This is because userActionCallback usually fires when the user has clicked something, but we select a payment method by default. If the payment method has a payment type fee, the client app wouldn't know it until they select another payment method and then select the first one again.