### PR TITLE
20555: Add organizationNumber and gln to contact model

### DIFF
--- a/orders-module/src/types/general.ts
+++ b/orders-module/src/types/general.ts
@@ -34,6 +34,8 @@ export type ContactRequestType = {
     city?: string;
     zip?: string;
     careOf?: string;
+    organizationNumber?: string;
+    gln?: string;
 };
 
 export type OrderDenialFallbackOfferType = {

--- a/orders-module/src/utils/order.helper.ts
+++ b/orders-module/src/utils/order.helper.ts
@@ -149,7 +149,10 @@ export const prepareContactModel = ({
             ? data.careOf?.trim() || undefined
             : undefined,
         organizationNumber,
-        gln: data.gln?.trim() || undefined,
+        gln:
+            data.paymentMethod === PaymentMethodEnum.OIO
+                ? data.gln?.trim() || undefined
+                : undefined,
     };
 
     return model;

--- a/orders-module/src/utils/order.helper.ts
+++ b/orders-module/src/utils/order.helper.ts
@@ -112,6 +112,11 @@ export const prepareContactModel = ({
     data,
     orderFields,
 }: ContactModelType) => {
+    const organizationNumber =
+        data.paymentMethod === PaymentMethodEnum.OIO
+            ? data.cvr?.trim() || undefined
+            : data.organizationNumber?.trim() || undefined;
+
     const model = {
         name: orderFields.find((i) => i.name === 'name')
             ? data.name?.trim() || undefined
@@ -143,6 +148,8 @@ export const prepareContactModel = ({
         careOf: orderFields.find((i) => i.name === 'careOf')
             ? data.careOf?.trim() || undefined
             : undefined,
+        organizationNumber,
+        gln: data.gln?.trim() || undefined,
     };
 
     return model;


### PR DESCRIPTION
This pull request updates the handling of organization-related fields in the contact model, improving support for organizational orders and standardizing data extraction and formatting. The most important changes are:

**Type and Model Updates:**

* Added optional `organizationNumber` and `gln` fields to the `ContactRequestType` type in `general.ts`, allowing these values to be captured for contact requests.
* Updated the `prepareContactModel` function to conditionally extract and trim the `organizationNumber` based on the payment method, ensuring correct assignment for OIO and other payment methods.
* Modified the contact model to include the new `organizationNumber` and `gln` fields, with values trimmed and set to `undefined` if missing.