### PR TITLE
20315: Update package ID as soon as fallback offer is fetched

### DIFF
--- a/orders-module/src/hooks/useOrderForm.tsx
+++ b/orders-module/src/hooks/useOrderForm.tsx
@@ -328,7 +328,8 @@ const useOrderForm = ({
                         .then((offer) => {
                             setOrderDenialFallbackOffer(offer);
                             if (offer?.templatePackageId) {
-                                fallbackOfferTemplatePackageIdRef.current = offer.templatePackageId;
+                                fallbackOfferTemplatePackageIdRef.current =
+                                    offer.templatePackageId;
                             }
                         })
                         .catch(() => {

--- a/orders-module/src/hooks/useOrderForm.tsx
+++ b/orders-module/src/hooks/useOrderForm.tsx
@@ -327,6 +327,9 @@ const useOrderForm = ({
                     void fetchDenialFallbackOffer(organizationId)
                         .then((offer) => {
                             setOrderDenialFallbackOffer(offer);
+                            if (offer?.templatePackageId) {
+                                fallbackOfferTemplatePackageIdRef.current = offer.templatePackageId;
+                            }
                         })
                         .catch(() => {
                             setOrderDenialFallbackOffer(undefined);


### PR DESCRIPTION
Update the package ID to use for the order as soon as fallback offer is fetched, so that even if the user clicks "Close" in the modal, the order will be created with fallback offer instead of templatePackageId.